### PR TITLE
Hide window on close instead of quiting the app

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,15 +11,6 @@ var WrappedWindow = require('./wrappedWindow');
 // be closed automatically when the JavaScript object is garbage collected.
 var mainWindow = null;
 
-// Quit when all windows are closed.
-app.on('window-all-closed', function() {
-  // On OS X it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
-    app.quit();
-  }
-});
-
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 app.on('ready', function() {
@@ -27,13 +18,5 @@ app.on('ready', function() {
     name: 'Google Hangouts Chat',
     url: 'https://chat.google.com/',
     openLocally: false
-  });
-
-  // Emitted when the window is closed.
-  mainWindow.on('closed', function() {
-    // Dereference the window object, usually you would store windows
-    // in an array if your app supports multi windows, this is the time
-    // when you should delete the corresponding element.
-    mainWindow = null;
   });
 });


### PR DESCRIPTION
Most chat applications leave the app open in background when you close the main window. In this PR, we now reproduce this behavior.

We also improve the app's context menu by removing the now useless "Toggle taskbar visibility" option, and merging the "Show" and "Hide" options in a single one with a dynamical label.

![Application context menu when the window is open: the first element reads "Hide window"](https://user-images.githubusercontent.com/7600265/59554030-d0f70d80-8f9d-11e9-88a5-fb194ece325b.png) ![Application context menu when the window is hidden: the first element reads "Show window"](https://user-images.githubusercontent.com/7600265/59554058-06036000-8f9e-11e9-80ae-45b72a2a7d46.png)


**Tested and working on:**
- [x] Arch Linux, GNOME Shell 3.32.2
- [x] macOS Mojave
- [x] Windows 10 Professional