### PR TITLE
Pipeline code used is the one based on tag

### DIFF
--- a/.github/workflows/release-desktop-package.yaml
+++ b/.github/workflows/release-desktop-package.yaml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          ref: master
 
       - name: Extract package version
         id: extract_package_version


### PR DESCRIPTION
Hi @squalou,

This little pull request to fix the source code used in pipeline to build release.
It was using master branch instead of the code associated to the tag !

Best regards,
CYOSP