### PR TITLE
Downgrade Electron to have systray icon back

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -637,9 +637,9 @@
       "dev": true
     },
     "electron": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-8.2.2.tgz",
-      "integrity": "sha512-GH4RCbpuzEn3XpTmsf+wLaJ2KOPSOoBJvQ0s6ftTLs5+IQEgKZvkdYCj8TCBNXFhss31RT3BUqoEQQUyZErK0A==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-7.2.4.tgz",
+      "integrity": "sha512-Z+R692uTzXgP8AHrabE+kkrMlQJ6pnAYoINenwj9QSqaD2YbO8IuXU9DMCcUY0+VpA91ee09wFZJNUKYPMnCKg==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "path": "0.12.7"
   },
   "devDependencies": {
-    "electron": "^8.0.0",
+    "electron": "^7.2.4",
     "electron-builder": ">=22.3.2"
   }
 }


### PR DESCRIPTION
Hi @squalou,

I've switched from KDE/Plasme to xfce and I've lost systray icon.
It was a really fight to understand why it was not working on xfce.

First I was on Debian stable (Buster), so xfce 4.12.5.
On a live xfce Arch Linux USB drive, the following demo repository for systray icon was working: https://github.com/electron/electron-api-demos.

So, I've tried to build a minimal Google Chat Electron app to reproduce.
I've succeed to build app with systray code but no icon displayed on my Debian stable xfce.

Last, I've decided to move from Debian stable to testing, so xfce 4.14.
But here also, systray icon of Google Chat was not working !

The only one staying change was the Electron version.
I've downgraded Electron version and it was working.

After some searches it seems: `not having the systray icon is a known "feature" of Electron 8`.
See first comment of issue here: https://github.com/keybase/keybase-issues/issues/3839.

Best regards,
CYOSP