### PR TITLE
Update login path in urls.  Fixes #40

### DIFF
--- a/src/window.js
+++ b/src/window.js
@@ -19,6 +19,7 @@ const urlNotRedirected = ["accounts/SetOSID?authuser=0&continue=https%3A%2F%2Fch
 						,"accounts.google.com"
 						,"accounts.youtube.com"
 						,"mail.google.com/ServiceLogin"
+						,"mail.google.com/chat"
 						,"https://chat.google.com/"
 						]
 


### PR DESCRIPTION
Add mail.google.com/chat to the list of URLs to prevent redirect and breaking out of app into regular browser on login. 

Fixes #40 