### PR TITLE
Fix system tray and app icon paths

### DIFF
--- a/src/paths.js
+++ b/src/paths.js
@@ -3,8 +3,8 @@ const {app} = require("electron");
 
 module.exports = {
 	"configsPath" : path.resolve(app.getPath("appData"), "google-hangouts-chat-linux.json"),
-	"iconPath" : path.resolve(path.dirname(__dirname), "assets/icon/icon.png"),
-	"NORMAL" : path.resolve(path.dirname(__dirname), "assets/icon/normal-64.png"),
-	"BADGE" : path.resolve(path.dirname(__dirname), "assets/icon/badge-64.png"),
-	"OFFLINE" : path.resolve(path.dirname(__dirname), "assets/icon/offline-64.png")
+	"iconPath" : path.resolve(path.dirname(__dirname), "assets", "icon", "icon.png"),
+	"NORMAL" : path.resolve(path.dirname(__dirname), "assets", "icon", "normal-64.png"),
+	"BADGE" : path.resolve(path.dirname(__dirname), "assets", "icon", "badge-64.png"),
+	"OFFLINE" : path.resolve(path.dirname(__dirname), "assets", "icon", "offline-64.png")
 }

--- a/src/paths.js
+++ b/src/paths.js
@@ -3,8 +3,8 @@ const {app} = require("electron");
 
 module.exports = {
 	"configsPath" : path.resolve(app.getPath("appData"), "google-hangouts-chat-linux.json"),
-	"iconPath" : path.resolve(process.resourcesPath, "icon/icon.png"),
-	"NORMAL" : path.resolve(process.resourcesPath, "icon/normal-64.png"),
-	"BADGE" : path.resolve(process.resourcesPath, "icon/badge-64.png"),
-	"OFFLINE" : path.resolve(process.resourcesPath, "icon/offline-64.png")
+	"iconPath" : path.resolve(__dirname, "../assets/icon/icon.png"),
+	"NORMAL" : path.resolve(__dirname, "../assets/icon/normal-64.png"),
+	"BADGE" : path.resolve(__dirname, "../assets/icon/badge-64.png"),
+	"OFFLINE" : path.resolve(__dirname,"../assets/icon/offline-64.png")
 }

--- a/src/paths.js
+++ b/src/paths.js
@@ -3,8 +3,8 @@ const {app} = require("electron");
 
 module.exports = {
 	"configsPath" : path.resolve(app.getPath("appData"), "google-hangouts-chat-linux.json"),
-	"iconPath" : path.resolve(__dirname, "../assets/icon/icon.png"),
-	"NORMAL" : path.resolve(__dirname, "../assets/icon/normal-64.png"),
-	"BADGE" : path.resolve(__dirname, "../assets/icon/badge-64.png"),
-	"OFFLINE" : path.resolve(__dirname,"../assets/icon/offline-64.png")
+	"iconPath" : path.resolve(path.dirname(__dirname), "assets/icon/icon.png"),
+	"NORMAL" : path.resolve(path.dirname(__dirname), "assets/icon/normal-64.png"),
+	"BADGE" : path.resolve(path.dirname(__dirname), "assets/icon/badge-64.png"),
+	"OFFLINE" : path.resolve(path.dirname(__dirname), "assets/icon/offline-64.png")
 }


### PR DESCRIPTION
This causes icons for system tray and application icons to successfully load by loading them from the assets path relative to path.js rather than the electron path.

Possibly fixes #56 and clears the related errors in Gnome 43 reported in #59 .