### PR TITLE
Provide a container to build deb and rpm packages

### DIFF
--- a/.github/workflows/release-desktop-package.yaml
+++ b/.github/workflows/release-desktop-package.yaml
@@ -48,12 +48,15 @@ jobs:
       - name: Install npm modules
         run: npm install
 
-      - name: Build desktop app
+      - name: Build deb desktop app
         run: npm run dist
 
-      - name: Create Debian check sum file
+      - name: Build rpm desktop app
+        run: npm run dist:rpm
+
+      - name: Create check sum file for deb and rpm
         if: matrix.config.os == 'ubuntu-latest'
-        run: sha512sum *.deb > google-chat-linux-SHA512.txt
+        run: sha512sum *.deb *.rpm > google-chat-linux-SHA512.txt
         working-directory: dist
 
       - name: Upload Debian package to release
@@ -67,7 +70,18 @@ jobs:
           asset_name: google-chat-linux_${{ steps.extract_package_version.outputs.version }}_amd64.deb
           asset_content_type: application/octet-stream
 
-      - name: Upload Debian check sum file to release
+      - name: Upload rpm package to release
+        if: matrix.config.os == 'ubuntu-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: dist/google-chat-linux_${{ steps.extract_package_version.outputs.version }}_x86_64.rpm
+          asset_name: google-chat-linux_${{ steps.extract_package_version.outputs.version }}_x86_64.rpm
+          asset_content_type: application/octet-stream
+
+      - name: Upload deb and rpm check sum file to release
         if: matrix.config.os == 'ubuntu-latest'
         uses: actions/upload-release-asset@v1
         env:

--- a/README.md
+++ b/README.md
@@ -312,13 +312,25 @@ a package 'google-chat-linux-bin' is availabe on AUR for Arch Linux and derivati
 
 ### manually build a deb package
 
-Run :
+You have two options - either install all build dependencies and then run :
 
 ```sh
 npm run dist
 ```
 
-will build a .deb file in `dist/`. Run for instance `sudo dkpg -i dist/google-chat-linux*.deb`.
+Or install docker (or podman) container engine and then create a local container with all build dependencies :
+
+```sh
+npm run container:setup
+```
+
+and then create the package by running:
+
+```sh
+npm run container:build:deb
+```
+
+In the end you'll end up with .deb file in `dist/`. Run for instance `sudo dkpg -i dist/google-chat-linux*.deb`.
 
 Installation of the .deb file is tested under Ubuntu, and works fine. Under Mint it installs well but react with emotes crashes the app. Go wonder.
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,22 @@ npm run dist
 A _Setup_.exe will be built under `\dist\` directory. 
 
 
+### rpm based distributions (Fedora)
+
+Install podman (or docker) container engine and then create a local container with all build dependencies :
+
+```sh
+npm run container:setup
+```
+
+and then create the package by running:
+
+```sh
+npm run container:build:rpm
+```
+
+In the end you'll end up with .rpm file in `dist/`. Run for instance `sudo dnf install dist/google-chat-linux*.rpm`.
+
 ## Systray Support
 
 **Note** : from 0.5 on, electron 9 bring back Tray integration BUT "click" events are ignored.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,10 @@ a package 'google-chat-linux-bin' is availabe on AUR for Arch Linux and derivati
 
 **Note** some environment variables are set in index.js : GTK_USE_PORTAL, ELECTRON_DISABLE_SANDBOX and NODE_OPTIONS="--no-force-async-hooks-checks". This *should* work. Else, set them manually.
 
+### rpm based (Fedora)
+
+[Have a look in tags](https://github.com/squalou/google-chat-linux/tags) section, download the relevant .rpm file and install with `sudo dnf install <package-name.rpm>` command.
+
 ### manually build a deb package
 
 You have two options - either install all build dependencies and then run :

--- a/containerbuild/Containerfile
+++ b/containerbuild/Containerfile
@@ -1,0 +1,21 @@
+FROM docker.io/library/buildpack-deps:focal-curl
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN \
+  # https://github.com/nodesource/distributions#ubuntu-versions
+  mkdir -p /etc/apt/keyrings && \
+  curl -sL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" >> /etc/apt/sources.list.d/nodesource.list && \
+  apt-get -qq update && \
+  # binutils provides ar - required to build deb \
+  apt-get -qq install --no-install-recommends -y nodejs binutils && \
+  apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /project
+
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV DEBUG_COLORS true
+ENV FORCE_COLOR true

--- a/containerbuild/Containerfile
+++ b/containerbuild/Containerfile
@@ -8,7 +8,8 @@ RUN \
   echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" >> /etc/apt/sources.list.d/nodesource.list && \
   apt-get -qq update && \
   # binutils provides ar - required to build deb \
-  apt-get -qq install --no-install-recommends -y nodejs binutils && \
+  # rpm provides rpmbuild - required to build rpm \
+  apt-get -qq install --no-install-recommends -y nodejs binutils rpm && \
   apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /project

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
     "dist:deb": "electron-builder --linux=deb",
+    "dist:rpm": "electron-builder --linux=rpm",
     "container:setup": "container_engine=${CONTAINER_ENGINE:-$(type -P podman || type -P docker)} && ${container_engine} build -t google-chat-linux-containerbuild containerbuild || >&2 echo 'Install podman or docker container engine to run this command.' && exit 1",
     "container:build": "scripts/in-container.sh npm install && scripts/in-container.sh npm run dist",
-    "container:build:deb": "scripts/in-container.sh npm install && scripts/in-container.sh npm run dist:deb"
+    "container:build:deb": "scripts/in-container.sh npm install && scripts/in-container.sh npm run dist:deb",
+    "container:build:rpm": "scripts/in-container.sh npm install && scripts/in-container.sh npm run dist:rpm"
   },
   "repository": "github.com:squalou/google-chat-linux.git",
   "homepage": "github.com:squalou/google-chat-linux.git",
@@ -29,6 +31,9 @@
       "depends": [
         "xdg-desktop-portal"
       ]
+    },
+    "rpm": {
+        "fpm": ["--rpm-rpmbuild-define=_build_id_links none"]
     },
     "win": {
       "target": [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "start": "electron .",
     "pack": "electron-builder --dir",
-    "dist": "electron-builder"
+    "dist": "electron-builder",
+    "dist:deb": "electron-builder --linux=deb",
+    "container:setup": "container_engine=${CONTAINER_ENGINE:-$(type -P podman || type -P docker)} && ${container_engine} build -t google-chat-linux-containerbuild containerbuild || >&2 echo 'Install podman or docker container engine to run this command.' && exit 1",
+    "container:build": "scripts/in-container.sh npm install && scripts/in-container.sh npm run dist",
+    "container:build:deb": "scripts/in-container.sh npm install && scripts/in-container.sh npm run dist:deb"
   },
   "repository": "github.com:squalou/google-chat-linux.git",
   "homepage": "github.com:squalou/google-chat-linux.git",

--- a/scripts/in-container.sh
+++ b/scripts/in-container.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -eu
+
+image=${CONTAINER_IMAGE_NAME:-"google-chat-linux-containerbuild"}
+
+# Initialize CONTAINER_ENGINE with a default value if not already set
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-}
+
+# Check if CONTAINER_ENGINE is set and valid
+if [ -n "$CONTAINER_ENGINE" ]; then
+    if ! type "$CONTAINER_ENGINE" &> /dev/null; then
+        >&2 echo "The specified CONTAINER_ENGINE '$CONTAINER_ENGINE' does not exist or is not executable."
+        exit 1
+    fi
+else
+    # If CONTAINER_ENGINE is empty, try setting it to podman or docker
+    if type podman &> /dev/null; then
+        CONTAINER_ENGINE="podman"
+    elif type docker &> /dev/null; then
+        CONTAINER_ENGINE="docker"
+    else
+        >&2 echo "Neither podman nor docker container engines found."
+        exit 1
+    fi
+fi
+
+if ! "${CONTAINER_ENGINE}" inspect "${image}" >/dev/null; then
+    echo "Container image ${image} not found. Have you run npm run container:setup?"
+    exit 1
+fi
+
+# Adapted https://www.electron.build/multi-platform-build#docker to podman
+"${CONTAINER_ENGINE}" run --rm -ti \
+  --env-file <(env | grep -iE 'DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|TRAVIS_TAG|TRAVIS|TRAVIS_REPO_|TRAVIS_BUILD_|TRAVIS_BRANCH|TRAVIS_PULL_REQUEST_|APPVEYOR_|CSC_|GH_|GITHUB_|BT_|AWS_|STRIP|BUILD_') \
+  --env ELECTRON_CACHE="/root/.cache/electron" \
+  --env ELECTRON_BUILDER_CACHE="/root/.cache/electron-builder" \
+  -v "${PWD}:/project:Z" \
+  -v "${PWD##*/}-node-modules:/project/node_modules:Z" \
+  -v ~/.cache/electron:/root/.cache/electron:Z \
+  -v ~/.cache/electron-builder:/root/.cache/electron-builder:Z \
+  "${image}" "$@"


### PR DESCRIPTION
This way one doesn't need to install build dependencies and it is enough to install a container engine (docker or podman).

Tested on Fedora 39 with podman to create and install rpm package.

Not tested with docker nor Debian-based distributions (I don't have one handy right now).

Edit: I have also extended GitHub action to create rpms but I haven't tested that one either.