### PR TITLE
Use GitHub web page as a home page

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dist": "electron-builder"
   },
   "repository": "github.com:squalou/google-chat-linux.git",
-  "homepage": "github.com:squalou/google-chat-linux.git",
+  "homepage": "https://github.com/squalou/google-chat-linux",
   "author": "Roberto Fasciolo <rob@robyf.net> (https://www.robyf.net/)",
   "license": "WTFPL",
   "build": {


### PR DESCRIPTION
URI set in homepage was redirected to this one - because that's used for git and not as a regular web page.