### PR TITLE
Support navigation from web browsers to the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,34 @@ To find out how Google Chat makes their themes, go to Developer Tools (<kbd>Ctrl
 
 can prove to be helpful.
 
+## Open Google Chat URLs from web browser in the app
+
+You can configure your web browser to detect Google Chat URLs and open them in the Google Chat Alt application:
+
+Step 0: Install Google Chat Alt.
+
+Step 1: Install a user script manager. See [Step 1 on Greasy Fork](https://greasyfork.org/) for various options.
+
+Note: the script manager must be able to cope with content security policy (CSP) headers. Tampermonkey on Firefox is known to work.
+
+Step 2: Install the user script [Google Chat Alt landing page](https://greasyfork.org/en/scripts/481609-google-chat-alt-landing-page) by clicking the green install button on the user script's page, and your user script manager will ask you to confirm the install.
+
+Step 3: Try it out by navigating e.g. to https://mail.google.com/chat/ in your web browser. If the user script is working correctly instead of Google Chat web UI your browser should ask you:
+
+> Allow this site to open the gchat link with Google Chat Alt?
+
+You can check the checkmark:
+
+> Always allow [...] to open gchat links
+
+Once you press the button Open Link, Google Chat Alt will be either started or (if you have it already running) restore its window. You can then close the tab in your browser.
+
+Note: If navigating to Google Chat opens Google Chat web UI the user script manager might not be compatible with the user script, Google might have changed something on the web site or you might have failed to install the script properly.
+
+Note: If navigating to Google Chat opens landing page that says "Launching Google Chat Alt" but web browser doesn't ask to open the link in the application, verify if you have installed Google Chat Alt. Running `gio mime x-scheme-handler/gchat` should display `google-chat-linux.desktop` as a default application.
+
+On technical level this functionality works in following way: Google Chat Alt uses [XDG Desktop file to claim to support URI scheme](https://developer.gnome.org/documentation/guidelines/maintainer/integrating.html#uri-schemes-handling) gchat://. No browser is able to handle this (made up) URI scheme but we use this to pass URI to the app. App looks for URI with this scheme and if found, it replaces gchat:// with https:// and navigates to that address. This should work for channel and direct message links out of box.
+
 ## Wayland support
 
 ### TL/DR; 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "appId": "Google Chat Linux",
     "linux": {
       "desktop": {
-        "Name": "Google Chat Alt"
+        "Name": "Google Chat Alt",
+        "MimeType": "x-scheme-handler/gchat;"
       },
       "category": "Network;InstantMessaging",
       "target": "deb"

--- a/src/window.js
+++ b/src/window.js
@@ -260,6 +260,11 @@ const handleRedirect = (e, url) => {
     return handled;
 };
 
+const getURL = (commandLine) => {
+    const foundItem = commandLine.find(item => item.startsWith('gchat://'));
+    return foundItem ? foundItem.replace('gchat://', 'https://') : null;
+};
+
 const initializeWindow = (config) => {
     const gotTheLock = app.requestSingleInstanceLock(undefined)
     if (!gotTheLock) {
@@ -271,6 +276,10 @@ const initializeWindow = (config) => {
                 if (mainWindow.isMinimized()) { mainWindow.restore() }
                 mainWindow.show()
                 mainWindow.focus()
+                const url = getURL(commandLine)
+                if (url) {
+                    mainWindow.loadURL(url)
+                }
             }
         })
     }
@@ -285,7 +294,12 @@ const initializeWindow = (config) => {
     thirdPartyAuthLoginMode = (config && config.thirdPartyAuthLoginMode);
 
     mainWindow = new BrowserWindow(bwOptions);
-    mainWindow.loadURL(extraOptions.url);
+
+    let url = getURL(process.argv)
+    if (!url) {
+        url = extraOptions.url
+    }
+    mainWindow.loadURL(url);
 
     if (config.languages !== undefined) {
         const ses = mainWindow.webContents.session


### PR DESCRIPTION
This requires User script https://greasyfork.org/en/scripts/481609-google-chat-alt-landing-page on extension(s) that are able to work around content security policy (CSP) headers - currently tested with Tampermonkey (see https://github.com/Tampermonkey/tampermonkey/issues/952#issuecomment-638373937 ) and it didn't work with Greasemonkey.

Once that is installed the user intercepts loading of https://chat.google.com/ with a static page that informs people that the link will be opened in an app like this:

![Screenshot 2023-12-07 at 14-33-22 Google Chat Alt landing page](https://github.com/squalou/google-chat-linux/assets/2543518/be214fa9-f919-49ed-bba4-97e20cd53b8f)

Technically it loads iframe with src where https:// of the Google Chat page was replaced with a psedo-scheme "gchat://".

Then following happens on the google-chat-linux end:

When generating XDG Desktop file claim support of gchat:// scheme (see https://developer.gnome.org/documentation/guidelines/maintainer/integrating.html#uri-schemes-handling ). If an URL with this scheme is passed on the command line replace that scheme with https:// one and navigate to that URL. This works for both new instance and when an instance is already running - for "second-instance".

---

I was inspired by similar approaches used by:
- Slack (uses `slack://`) - e.g. (click on the thumbnail for full image) <br><a href="https://github.com/squalou/google-chat-linux/assets/2543518/676a0451-753b-47b8-90b1-ef81f5efa99d"><img width="30%" src="https://github.com/squalou/google-chat-linux/assets/2543518/676a0451-753b-47b8-90b1-ef81f5efa99d"></a>
- Telegram (uses `t://`)  - e.g. https://t.me/publictestgroup (click on the thumbnail for full image) <br><a href="https://github.com/squalou/google-chat-linux/assets/2543518/6efdef7a-3385-4894-8caf-cde0012bed3d"><img width="30%" src="https://github.com/squalou/google-chat-linux/assets/2543518/6efdef7a-3385-4894-8caf-cde0012bed3d"></a>