### PR TITLE
Major electron update 28.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "electron-context-menu": "^3.5.0"
       },
       "devDependencies": {
-        "electron": "27.0.3",
+        "electron": "28.0.0",
         "electron-builder": "^24.4.0"
       },
       "engines": {
@@ -1768,9 +1768,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "27.0.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-27.0.3.tgz",
-      "integrity": "sha512-VaB9cI1se+mUtz366NP+zxFVnkHLbCBNO4wwouw3FuGyX/m7/Bv1I89JhWOBv78tC+n11ZYMrVD23Jf6EZgVcg==",
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-28.0.0.tgz",
+      "integrity": "sha512-eDhnCFBvG0PGFVEpNIEdBvyuGUBsFdlokd+CtuCe2ER3P+17qxaRfWRxMmksCOKgDHb5Wif5UxqOkZSlA4snlw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "electron-context-menu": "^3.5.0"
   },
   "devDependencies": {
-    "electron": "27.0.3",
+    "electron": "28.0.0",
     "electron-builder": "^24.4.0"
   }
 }


### PR DESCRIPTION
See release notes https://releases.electronjs.org/release/v28.0.0

In Wayland world interesting new feature is:

    Added support for ELECTRON_OZONE_PLATFORM_HINT environment variable
    on Linux.