### PR TITLE
Fix native notifications for unread chats

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "google-chat-linux",
   "version": "5.39.25-1",
   "description": "Unofficial alternative Google Chat desktop app",
+  "desktopName": "google-chat-linux.desktop",
   "main": "src/index.js",
   "scripts": {
+    "test": "node --test",
     "start": "electron .",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",

--- a/src/configs.js
+++ b/src/configs.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const pathsManifest = require("./paths");
 const process = require("process");
+const { normalizeNotificationLanguage } = require("./notificationMessages");
 
 const setConfigDefaults = (configuration) => {
     configuration.keepMinimized = configuration.keepMinimized === undefined ? true : configuration.keepMinimized;
@@ -16,6 +17,7 @@ const setConfigDefaults = (configuration) => {
     configuration.languages = configuration.languages === undefined ? undefined : configuration.languages;
     configuration.iconTheme = configuration.iconTheme === undefined ? 'default' : configuration.iconTheme;
     configuration.useTray = configuration.useTray === undefined ? true : configuration.useTray;
+    configuration.notificationLanguage = normalizeNotificationLanguage(configuration.notificationLanguage);
     pathsManifest.setIconTheme(configuration.iconTheme)
     if (process.platform === 'win32') {
         configuration.keepMinimized = true;

--- a/src/configs.js
+++ b/src/configs.js
@@ -18,6 +18,7 @@ const setConfigDefaults = (configuration) => {
     configuration.iconTheme = configuration.iconTheme === undefined ? 'default' : configuration.iconTheme;
     configuration.useTray = configuration.useTray === undefined ? true : configuration.useTray;
     configuration.notificationLanguage = normalizeNotificationLanguage(configuration.notificationLanguage);
+    configuration.enableNativeNotifications = configuration.enableNativeNotifications === undefined ? true : configuration.enableNativeNotifications;
     pathsManifest.setIconTheme(configuration.iconTheme)
     if (process.platform === 'win32') {
         configuration.keepMinimized = true;

--- a/src/faviconState.js
+++ b/src/faviconState.js
@@ -25,7 +25,14 @@ const classifyFavicon = (href = "") => {
     return ICON_TYPES.OFFLINE;
 };
 
-const transitionUnreadState = (hasUnread, iconType) => {
+const transitionUnreadState = (hasUnread, iconType, notificationsEnabled = true) => {
+    if (!notificationsEnabled) {
+        return {
+            hasUnread: false,
+            action: UNREAD_ACTIONS.NONE
+        };
+    }
+
     if (iconType === ICON_TYPES.ATTENTION && !hasUnread) {
         return {
             hasUnread: true,

--- a/src/faviconState.js
+++ b/src/faviconState.js
@@ -1,0 +1,54 @@
+const ICON_TYPES = Object.freeze({
+    NORMAL: "NORMAL",
+    ATTENTION: "ATTENTION",
+    OFFLINE: "OFFLINE"
+});
+
+const UNREAD_ACTIONS = Object.freeze({
+    SHOW: "SHOW",
+    CLOSE: "CLOSE",
+    NONE: "NONE"
+});
+
+const classifyFavicon = (href = "") => {
+    if (href.match(/logo_favicon_no_dot/) ||
+        href.match(/favicon_chat_new_non_notif_r/) ||
+        href.match(/favicon_chat_r/)) {
+        return ICON_TYPES.NORMAL;
+    }
+
+    if (href.match(/logo_favicon_dot/) ||
+        href.match(/favicon_chat_new_notif_r/)) {
+        return ICON_TYPES.ATTENTION;
+    }
+
+    return ICON_TYPES.OFFLINE;
+};
+
+const transitionUnreadState = (hasUnread, iconType) => {
+    if (iconType === ICON_TYPES.ATTENTION && !hasUnread) {
+        return {
+            hasUnread: true,
+            action: UNREAD_ACTIONS.SHOW
+        };
+    }
+
+    if (iconType === ICON_TYPES.NORMAL && hasUnread) {
+        return {
+            hasUnread: false,
+            action: UNREAD_ACTIONS.CLOSE
+        };
+    }
+
+    return {
+        hasUnread,
+        action: UNREAD_ACTIONS.NONE
+    };
+};
+
+module.exports = {
+    ICON_TYPES,
+    UNREAD_ACTIONS,
+    classifyFavicon,
+    transitionUnreadState
+};

--- a/src/notificationMessages.js
+++ b/src/notificationMessages.js
@@ -1,6 +1,12 @@
 const NOTIFICATION_LANGUAGES = Object.freeze({
     ENGLISH: "en",
-    POLISH: "pl"
+    GERMAN: "de",
+    SPANISH: "es",
+    FRENCH: "fr",
+    ITALIAN: "it",
+    DUTCH: "nl",
+    POLISH: "pl",
+    PORTUGUESE: "pt"
 });
 
 const MESSAGES = Object.freeze({
@@ -8,11 +14,46 @@ const MESSAGES = Object.freeze({
         unread: "You have unread messages in Google Chat",
         test: "Native notifications are working correctly"
     }),
+    [NOTIFICATION_LANGUAGES.GERMAN]: Object.freeze({
+        unread: "Du hast ungelesene Nachrichten in Google Chat",
+        test: "Native Benachrichtigungen funktionieren korrekt"
+    }),
+    [NOTIFICATION_LANGUAGES.SPANISH]: Object.freeze({
+        unread: "Tienes mensajes sin leer en Google Chat",
+        test: "Las notificaciones nativas funcionan correctamente"
+    }),
+    [NOTIFICATION_LANGUAGES.FRENCH]: Object.freeze({
+        unread: "Vous avez des messages non lus dans Google Chat",
+        test: "Les notifications natives fonctionnent correctement"
+    }),
+    [NOTIFICATION_LANGUAGES.ITALIAN]: Object.freeze({
+        unread: "Hai messaggi non letti in Google Chat",
+        test: "Le notifiche native funzionano correttamente"
+    }),
+    [NOTIFICATION_LANGUAGES.DUTCH]: Object.freeze({
+        unread: "Je hebt ongelezen berichten in Google Chat",
+        test: "Native meldingen werken correct"
+    }),
     [NOTIFICATION_LANGUAGES.POLISH]: Object.freeze({
         unread: "Masz nieprzeczytane wiadomości w Google Chat",
         test: "Natywne powiadomienia działają poprawnie"
+    }),
+    [NOTIFICATION_LANGUAGES.PORTUGUESE]: Object.freeze({
+        unread: "Há mensagens não lidas no Google Chat",
+        test: "As notificações nativas funcionam corretamente"
     })
 });
+
+const NOTIFICATION_LANGUAGE_OPTIONS = Object.freeze([
+    Object.freeze({ code: NOTIFICATION_LANGUAGES.ENGLISH, label: "English" }),
+    Object.freeze({ code: NOTIFICATION_LANGUAGES.GERMAN, label: "Deutsch" }),
+    Object.freeze({ code: NOTIFICATION_LANGUAGES.SPANISH, label: "Español" }),
+    Object.freeze({ code: NOTIFICATION_LANGUAGES.FRENCH, label: "Français" }),
+    Object.freeze({ code: NOTIFICATION_LANGUAGES.ITALIAN, label: "Italiano" }),
+    Object.freeze({ code: NOTIFICATION_LANGUAGES.DUTCH, label: "Nederlands" }),
+    Object.freeze({ code: NOTIFICATION_LANGUAGES.POLISH, label: "Polski" }),
+    Object.freeze({ code: NOTIFICATION_LANGUAGES.PORTUGUESE, label: "Português" })
+]);
 
 const normalizeNotificationLanguage = (language) => {
     return MESSAGES[language] ? language : NOTIFICATION_LANGUAGES.ENGLISH;
@@ -24,6 +65,7 @@ const getNotificationMessages = (language) => {
 
 module.exports = {
     NOTIFICATION_LANGUAGES,
+    NOTIFICATION_LANGUAGE_OPTIONS,
     normalizeNotificationLanguage,
     getNotificationMessages
 };

--- a/src/notificationMessages.js
+++ b/src/notificationMessages.js
@@ -1,0 +1,29 @@
+const NOTIFICATION_LANGUAGES = Object.freeze({
+    ENGLISH: "en",
+    POLISH: "pl"
+});
+
+const MESSAGES = Object.freeze({
+    [NOTIFICATION_LANGUAGES.ENGLISH]: Object.freeze({
+        unread: "You have unread messages in Google Chat",
+        test: "Native notifications are working correctly"
+    }),
+    [NOTIFICATION_LANGUAGES.POLISH]: Object.freeze({
+        unread: "Masz nieprzeczytane wiadomości w Google Chat",
+        test: "Natywne powiadomienia działają poprawnie"
+    })
+});
+
+const normalizeNotificationLanguage = (language) => {
+    return MESSAGES[language] ? language : NOTIFICATION_LANGUAGES.ENGLISH;
+};
+
+const getNotificationMessages = (language) => {
+    return MESSAGES[normalizeNotificationLanguage(language)];
+};
+
+module.exports = {
+    NOTIFICATION_LANGUAGES,
+    normalizeNotificationLanguage,
+    getNotificationMessages
+};

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -1,0 +1,106 @@
+const { Notification } = require("electron");
+const pathsManifest = require("./paths");
+const { UNREAD_ACTIONS, transitionUnreadState } = require("./faviconState");
+const {
+    NOTIFICATION_LANGUAGES,
+    normalizeNotificationLanguage,
+    getNotificationMessages
+} = require("./notificationMessages");
+
+let mainWindow;
+let hasUnread = false;
+let unreadNotification;
+let notificationLanguage = NOTIFICATION_LANGUAGES.ENGLISH;
+const activeNotifications = new Set();
+
+const showMainWindow = () => {
+    if (!mainWindow || mainWindow.isDestroyed()) {
+        return;
+    }
+
+    if (mainWindow.isMinimized()) {
+        mainWindow.restore();
+    }
+    mainWindow.show();
+    mainWindow.focus();
+};
+
+const retainNotification = (notification, isUnreadNotification = false) => {
+    activeNotifications.add(notification);
+
+    const release = () => {
+        activeNotifications.delete(notification);
+        if (isUnreadNotification && unreadNotification === notification) {
+            unreadNotification = undefined;
+        }
+    };
+
+    notification.on("click", () => {
+        showMainWindow();
+        release();
+    });
+    notification.on("close", release);
+    notification.on("failed", (event, error) => {
+        console.error("Failed to show native notification:", error);
+        release();
+    });
+
+    return notification;
+};
+
+const createNotification = (options, isUnreadNotification = false) => {
+    if (!Notification.isSupported()) {
+        console.warn("Native notifications are not supported on this system");
+        return undefined;
+    }
+
+    const notification = retainNotification(
+        new Notification({
+            icon: pathsManifest.normal(),
+            ...options
+        }),
+        isUnreadNotification
+    );
+    notification.show();
+    return notification;
+};
+
+const setMainWindow = (windowObj) => {
+    mainWindow = windowObj;
+};
+
+const setNotificationLanguage = (language) => {
+    notificationLanguage = normalizeNotificationLanguage(language);
+};
+
+const updateUnreadState = (iconType) => {
+    const nextState = transitionUnreadState(hasUnread, iconType);
+    hasUnread = nextState.hasUnread;
+
+    if (nextState.action === UNREAD_ACTIONS.SHOW) {
+        const messages = getNotificationMessages(notificationLanguage);
+        unreadNotification = createNotification({
+            title: "Google Chat",
+            body: messages.unread,
+            timeoutType: "never"
+        }, true);
+    } else if (nextState.action === UNREAD_ACTIONS.CLOSE) {
+        unreadNotification?.close();
+        unreadNotification = undefined;
+    }
+};
+
+const showTestNotification = () => {
+    const messages = getNotificationMessages(notificationLanguage);
+    createNotification({
+        title: "Google Chat",
+        body: messages.test
+    });
+};
+
+module.exports = {
+    setMainWindow,
+    setNotificationLanguage,
+    updateUnreadState,
+    showTestNotification
+};

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -11,6 +11,7 @@ let mainWindow;
 let hasUnread = false;
 let unreadNotification;
 let notificationLanguage = NOTIFICATION_LANGUAGES.ENGLISH;
+let nativeNotificationsEnabled = true;
 const activeNotifications = new Set();
 
 const showMainWindow = () => {
@@ -73,8 +74,25 @@ const setNotificationLanguage = (language) => {
     notificationLanguage = normalizeNotificationLanguage(language);
 };
 
+const closeAllNotifications = () => {
+    for (const notification of [...activeNotifications]) {
+        notification.close();
+    }
+    activeNotifications.clear();
+    unreadNotification = undefined;
+};
+
+const setNativeNotificationsEnabled = (enabled) => {
+    nativeNotificationsEnabled = Boolean(enabled);
+    hasUnread = false;
+
+    if (!nativeNotificationsEnabled) {
+        closeAllNotifications();
+    }
+};
+
 const updateUnreadState = (iconType) => {
-    const nextState = transitionUnreadState(hasUnread, iconType);
+    const nextState = transitionUnreadState(hasUnread, iconType, nativeNotificationsEnabled);
     hasUnread = nextState.hasUnread;
 
     if (nextState.action === UNREAD_ACTIONS.SHOW) {
@@ -91,6 +109,10 @@ const updateUnreadState = (iconType) => {
 };
 
 const showTestNotification = () => {
+    if (!nativeNotificationsEnabled) {
+        return;
+    }
+
     const messages = getNotificationMessages(notificationLanguage);
     createNotification({
         title: "Google Chat",
@@ -101,6 +123,7 @@ const showTestNotification = () => {
 module.exports = {
     setMainWindow,
     setNotificationLanguage,
+    setNativeNotificationsEnabled,
     updateUnreadState,
     showTestNotification
 };

--- a/src/tray.js
+++ b/src/tray.js
@@ -2,6 +2,8 @@ const { Tray, Menu, ipcMain } = require("electron");
 //const path = require("path");
 const pathsManifest = require("./paths");
 const WindowManager = require('./window');
+const NotificationManager = require("./notifications");
+const { ICON_TYPES, classifyFavicon } = require("./faviconState");
 let mainWindow;
 let systemTrayIcon;
 const onShowEntryClicked = () => {
@@ -72,24 +74,15 @@ const initializeTray = (windowObj) => {
 };
 
 ipcMain.on('favicon-changed', (evt, href) => {
-    var itype = "";
-    if (href.match(/logo_favicon_no_dot/) ||
-        href.match(/favicon_chat_new_non_notif_r/) ||
-        href.match(/favicon_chat_r/)) {
-        itype = "NORMAL";
-    } else if (href.match(/logo_favicon_dot/) ||
-        href.match(/favicon_chat_new_notif_r/)) {
-        itype = "ATTENTION";
-    } else {
-        itype = "OFFLINE";
-    }
-    setIcon(itype);
+    const iconType = classifyFavicon(href);
+    setIcon(iconType);
+    NotificationManager.updateUnreadState(iconType);
 });
 
 function iconForType(iconType) {
-    if (iconType == "NORMAL") {
+    if (iconType == ICON_TYPES.NORMAL) {
         return pathsManifest.normal();
-    } else if (iconType == "ATTENTION") {
+    } else if (iconType == ICON_TYPES.ATTENTION) {
         return pathsManifest.badge();
     } else {
         return pathsManifest.offline();
@@ -107,7 +100,7 @@ const setIcon = (iconType) => {
     }
     WindowManager.updateIcon(i);
 
-    if (iconType == "ATTENTION") {
+    if (iconType == ICON_TYPES.ATTENTION) {
         WindowManager.setOverlayIcon();
     } else {
         WindowManager.cleanOverlayIcon();

--- a/src/window.js
+++ b/src/window.js
@@ -3,6 +3,11 @@ const path = require("path");
 const pathsManifest = require("./paths");
 const { platform } = require("process");
 const ConfigManager = require("./configs");
+const NotificationManager = require("./notifications");
+const {
+    NOTIFICATION_LANGUAGES,
+    normalizeNotificationLanguage
+} = require("./notificationMessages");
 
 const DEFAULT_ICONS = 'default'
 const COLORED_ICONS = 'colored'
@@ -17,6 +22,7 @@ let enableNodeIntegration = true;
 let openUrlInside = false;
 let useXdgOpen = false;
 let thirdPartyAuthLoginMode = false;
+let notificationLanguage = NOTIFICATION_LANGUAGES.ENGLISH;
 
 const noRedirectUrlArrayHardcoded = ["accounts/SetOSID?authuser=0&continue=https%3A%2F%2Fchat.google.com"
     , "accounts.google.com"
@@ -192,6 +198,12 @@ const onForceReloadClicked = () => {
     mainWindow.webContents.reload();
 }
 
+const onSetNotificationLanguageClicked = (language) => {
+    notificationLanguage = normalizeNotificationLanguage(language);
+    NotificationManager.setNotificationLanguage(notificationLanguage);
+    buildMenu();
+};
+
 const updateIcon = (icon) => {
     try {
         mainWindow.setIcon(icon);
@@ -323,7 +335,10 @@ const initializeWindow = (config) => {
     thirdPartyAuthLoginMode = (config && config.thirdPartyAuthLoginMode);
     iconTheme = (config && config.iconTheme)
     useTray = (config && config.useTray)
+    notificationLanguage = normalizeNotificationLanguage(config && config.notificationLanguage);
     mainWindow = new BrowserWindow(bwOptions);
+    NotificationManager.setMainWindow(mainWindow);
+    NotificationManager.setNotificationLanguage(notificationLanguage);
 
     //mainWindow.webContents.openDevTools();
     // if(process.platform === "linux" && ! config.keepMinimized){
@@ -374,6 +389,7 @@ const initializeWindow = (config) => {
             configsData.thirdPartyAuthLoginMode = thirdPartyAuthLoginMode;
             configsData.iconTheme = iconTheme;
             configsData.useTray = useTray;
+            configsData.notificationLanguage = notificationLanguage;
             ConfigManager.updateConfigs(configsData);
         } else {
             e.preventDefault();
@@ -436,6 +452,30 @@ const menuSubMenu = () => {
             click: () => {
                 onForceReloadClicked();
             }
+        }, {
+            label: 'Test native notification',
+            click: () => {
+                NotificationManager.showTestNotification();
+            }
+        }, {
+            label: 'Notification language',
+            submenu: [
+                {
+                    label: 'English',
+                    type: 'radio',
+                    checked: notificationLanguage === NOTIFICATION_LANGUAGES.ENGLISH,
+                    click: () => {
+                        onSetNotificationLanguageClicked(NOTIFICATION_LANGUAGES.ENGLISH);
+                    }
+                }, {
+                    label: 'Polski',
+                    type: 'radio',
+                    checked: notificationLanguage === NOTIFICATION_LANGUAGES.POLISH,
+                    click: () => {
+                        onSetNotificationLanguageClicked(NOTIFICATION_LANGUAGES.POLISH);
+                    }
+                }
+            ]
         }, {
             label: getEnableKeyboardShortcuts() ? "Disable alt left/right shortcuts (restart)" : "Enable alt left/right shortcuts (restart)",
             click: () => {

--- a/src/window.js
+++ b/src/window.js
@@ -24,6 +24,7 @@ let openUrlInside = false;
 let useXdgOpen = false;
 let thirdPartyAuthLoginMode = false;
 let notificationLanguage = NOTIFICATION_LANGUAGES.ENGLISH;
+let enableNativeNotifications = true;
 
 const noRedirectUrlArrayHardcoded = ["accounts/SetOSID?authuser=0&continue=https%3A%2F%2Fchat.google.com"
     , "accounts.google.com"
@@ -205,6 +206,13 @@ const onSetNotificationLanguageClicked = (language) => {
     buildMenu();
 };
 
+const onSetNativeNotificationsEnabled = (enabled) => {
+    enableNativeNotifications = Boolean(enabled);
+    NotificationManager.setNativeNotificationsEnabled(enableNativeNotifications);
+    ConfigManager.updateConfigs({ enableNativeNotifications });
+    buildMenu();
+};
+
 const updateIcon = (icon) => {
     try {
         mainWindow.setIcon(icon);
@@ -337,9 +345,11 @@ const initializeWindow = (config) => {
     iconTheme = (config && config.iconTheme)
     useTray = (config && config.useTray)
     notificationLanguage = normalizeNotificationLanguage(config && config.notificationLanguage);
+    enableNativeNotifications = (config && config.enableNativeNotifications) !== false;
     mainWindow = new BrowserWindow(bwOptions);
     NotificationManager.setMainWindow(mainWindow);
     NotificationManager.setNotificationLanguage(notificationLanguage);
+    NotificationManager.setNativeNotificationsEnabled(enableNativeNotifications);
 
     //mainWindow.webContents.openDevTools();
     // if(process.platform === "linux" && ! config.keepMinimized){
@@ -391,6 +401,7 @@ const initializeWindow = (config) => {
             configsData.iconTheme = iconTheme;
             configsData.useTray = useTray;
             configsData.notificationLanguage = notificationLanguage;
+            configsData.enableNativeNotifications = enableNativeNotifications;
             ConfigManager.updateConfigs(configsData);
         } else {
             e.preventDefault();
@@ -454,7 +465,15 @@ const menuSubMenu = () => {
                 onForceReloadClicked();
             }
         }, {
+            label: 'Enable native notifications',
+            type: 'checkbox',
+            checked: enableNativeNotifications,
+            click: (menuItem) => {
+                onSetNativeNotificationsEnabled(menuItem.checked);
+            }
+        }, {
             label: 'Test native notification',
+            enabled: enableNativeNotifications,
             click: () => {
                 NotificationManager.showTestNotification();
             }

--- a/src/window.js
+++ b/src/window.js
@@ -6,6 +6,7 @@ const ConfigManager = require("./configs");
 const NotificationManager = require("./notifications");
 const {
     NOTIFICATION_LANGUAGES,
+    NOTIFICATION_LANGUAGE_OPTIONS,
     normalizeNotificationLanguage
 } = require("./notificationMessages");
 
@@ -459,23 +460,14 @@ const menuSubMenu = () => {
             }
         }, {
             label: 'Notification language',
-            submenu: [
-                {
-                    label: 'English',
-                    type: 'radio',
-                    checked: notificationLanguage === NOTIFICATION_LANGUAGES.ENGLISH,
-                    click: () => {
-                        onSetNotificationLanguageClicked(NOTIFICATION_LANGUAGES.ENGLISH);
-                    }
-                }, {
-                    label: 'Polski',
-                    type: 'radio',
-                    checked: notificationLanguage === NOTIFICATION_LANGUAGES.POLISH,
-                    click: () => {
-                        onSetNotificationLanguageClicked(NOTIFICATION_LANGUAGES.POLISH);
-                    }
+            submenu: NOTIFICATION_LANGUAGE_OPTIONS.map(({ code, label }) => ({
+                label,
+                type: 'radio',
+                checked: notificationLanguage === code,
+                click: () => {
+                    onSetNotificationLanguageClicked(code);
                 }
-            ]
+            }))
         }, {
             label: getEnableKeyboardShortcuts() ? "Disable alt left/right shortcuts (restart)" : "Enable alt left/right shortcuts (restart)",
             click: () => {

--- a/test/faviconState.test.js
+++ b/test/faviconState.test.js
@@ -57,6 +57,16 @@ test("shows only once while the favicon remains in attention state", () => {
     );
 });
 
+test("suppresses unread notifications when native notifications are disabled", () => {
+    assert.deepEqual(
+        transitionUnreadState(false, ICON_TYPES.ATTENTION, false),
+        {
+            hasUnread: false,
+            action: UNREAD_ACTIONS.NONE
+        }
+    );
+});
+
 test("offline preserves unread state and normal clears it", () => {
     const offline = transitionUnreadState(true, ICON_TYPES.OFFLINE);
     assert.deepEqual(offline, {

--- a/test/faviconState.test.js
+++ b/test/faviconState.test.js
@@ -1,0 +1,85 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+    ICON_TYPES,
+    UNREAD_ACTIONS,
+    classifyFavicon,
+    transitionUnreadState
+} = require("../src/faviconState");
+
+test("classifies current Google Chat normal favicon variants", () => {
+    assert.equal(
+        classifyFavicon("https://chat.google.com/logo_favicon_no_dot_2026.png"),
+        ICON_TYPES.NORMAL
+    );
+    assert.equal(
+        classifyFavicon("https://chat.google.com/favicon_chat_new_non_notif_r.png"),
+        ICON_TYPES.NORMAL
+    );
+    assert.equal(
+        classifyFavicon("https://chat.google.com/favicon_chat_r.png"),
+        ICON_TYPES.NORMAL
+    );
+});
+
+test("classifies current Google Chat attention favicon variants", () => {
+    assert.equal(
+        classifyFavicon("https://chat.google.com/logo_favicon_dot_2026.png"),
+        ICON_TYPES.ATTENTION
+    );
+    assert.equal(
+        classifyFavicon("https://chat.google.com/favicon_chat_new_notif_r.png"),
+        ICON_TYPES.ATTENTION
+    );
+});
+
+test("classifies an absent or unknown favicon as offline", () => {
+    assert.equal(classifyFavicon(), ICON_TYPES.OFFLINE);
+    assert.equal(
+        classifyFavicon("data:image/png;base64,unknown"),
+        ICON_TYPES.OFFLINE
+    );
+});
+
+test("shows only once while the favicon remains in attention state", () => {
+    const first = transitionUnreadState(false, ICON_TYPES.ATTENTION);
+    assert.deepEqual(first, {
+        hasUnread: true,
+        action: UNREAD_ACTIONS.SHOW
+    });
+
+    assert.deepEqual(
+        transitionUnreadState(first.hasUnread, ICON_TYPES.ATTENTION),
+        {
+            hasUnread: true,
+            action: UNREAD_ACTIONS.NONE
+        }
+    );
+});
+
+test("offline preserves unread state and normal clears it", () => {
+    const offline = transitionUnreadState(true, ICON_TYPES.OFFLINE);
+    assert.deepEqual(offline, {
+        hasUnread: true,
+        action: UNREAD_ACTIONS.NONE
+    });
+
+    assert.deepEqual(
+        transitionUnreadState(offline.hasUnread, ICON_TYPES.NORMAL),
+        {
+            hasUnread: false,
+            action: UNREAD_ACTIONS.CLOSE
+        }
+    );
+});
+
+test("a new attention cycle shows another notification after clearing", () => {
+    const cleared = transitionUnreadState(true, ICON_TYPES.NORMAL);
+    assert.deepEqual(
+        transitionUnreadState(cleared.hasUnread, ICON_TYPES.ATTENTION),
+        {
+            hasUnread: true,
+            action: UNREAD_ACTIONS.SHOW
+        }
+    );
+});

--- a/test/notificationMessages.test.js
+++ b/test/notificationMessages.test.js
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const {
     NOTIFICATION_LANGUAGES,
+    NOTIFICATION_LANGUAGE_OPTIONS,
     normalizeNotificationLanguage,
     getNotificationMessages
 } = require("../src/notificationMessages");
@@ -19,4 +20,17 @@ test("provides Polish notification messages when selected", () => {
         unread: "Masz nieprzeczytane wiadomości w Google Chat",
         test: "Natywne powiadomienia działają poprawnie"
     });
+});
+
+test("provides messages for every selectable notification language", () => {
+    const languageCodes = NOTIFICATION_LANGUAGE_OPTIONS.map(({ code }) => code);
+    assert.equal(new Set(languageCodes).size, languageCodes.length);
+
+    for (const { code, label } of NOTIFICATION_LANGUAGE_OPTIONS) {
+        assert.equal(normalizeNotificationLanguage(code), code, label);
+
+        const messages = getNotificationMessages(code);
+        assert.ok(messages.unread.length > 0, `${label} unread message`);
+        assert.ok(messages.test.length > 0, `${label} test message`);
+    }
 });

--- a/test/notificationMessages.test.js
+++ b/test/notificationMessages.test.js
@@ -1,0 +1,22 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+    NOTIFICATION_LANGUAGES,
+    normalizeNotificationLanguage,
+    getNotificationMessages
+} = require("../src/notificationMessages");
+
+test("uses English notification messages by default", () => {
+    assert.equal(normalizeNotificationLanguage(), NOTIFICATION_LANGUAGES.ENGLISH);
+    assert.deepEqual(getNotificationMessages(), {
+        unread: "You have unread messages in Google Chat",
+        test: "Native notifications are working correctly"
+    });
+});
+
+test("provides Polish notification messages when selected", () => {
+    assert.deepEqual(getNotificationMessages(NOTIFICATION_LANGUAGES.POLISH), {
+        unread: "Masz nieprzeczytane wiadomości w Google Chat",
+        test: "Natywne powiadomienia działają poprawnie"
+    });
+});


### PR DESCRIPTION
## Summary

- add a main-process native notification fallback driven by the existing unread favicon signal
- keep one persistent notification while chats are unread, preserve it through offline state, and close it after the favicon returns to normal
- restore and focus the Google Chat window when the notification is clicked
- set `desktopName` so Linux notification daemons can associate notifications with `google-chat-linux.desktop`
- add a native notification test action and persisted language selection for English, German, Spanish, French, Italian, Dutch, Polish, and Portuguese
- add a persisted, default-on toggle to disable native notifications without affecting unread icon updates
- extract favicon classification and unread-state transitions into testable modules

## Root cause

Google Chat uses persistent Service Worker notifications through
`ServiceWorkerRegistration.showNotification()`. Electron records those notifications, but does
not forward them to the native notification service. This is the long-standing upstream
limitation tracked in https://github.com/electron/electron/issues/13041.

Classic Electron `Notification` objects use the native notification path correctly on Linux, so
this change uses the favicon state already observed by the preload script as a privacy-preserving
fallback signal. It does not inject code into Google Chat or modify its Service Worker.

## Behavior

- the first transition to the attention favicon creates one generic persistent notification
- repeated attention favicon events do not create duplicates
- offline state preserves the current unread notification
- returning to the normal favicon closes the notification
- manually closing the notification removes the desktop badge; another notification is created
  after the next normal-to-attention cycle
- disabling native notifications closes active notifications and suppresses new ones while leaving
  unread icon updates unchanged
- the notification contains no message or sender content

On KDE Plasma this allows notification badge integrations such as
`plasma-task-manager-notifications` to associate the active notification with the application.

## Validation

- `npm test` (10 tests)
- syntax checks for all files in `src/` and `test/`
- `npm run pack`
- `git diff --check`
- manually verified native notification and task-manager badge behavior on Arch Linux,
  KDE Plasma 6, and Wayland with Electron 39

## Known limitation

Google Chat's own **Settings → Notifications → Show example** action still uses the unsupported
Service Worker notification path. The new **Menu → Test native notification** action tests the
fallback implemented here.
